### PR TITLE
fix typo in OpenID token grant sample response

### DIFF
--- a/doc_source/authorization-endpoint.md
+++ b/doc_source/authorization-endpoint.md
@@ -149,7 +149,7 @@ The authorization server redirects back to your app with access token and ID tok
 
 ```
 HTTP/1.1 302 Found
-Location: https://YOUR_APP/redirect_ur#id_token=ID_TOKEN&access_token=ACCESS_TOKEN&token_type=bearer&expires_in=3600&state=STATE
+Location: https://YOUR_APP/redirect_uri#id_token=ID_TOKEN&access_token=ACCESS_TOKEN&token_type=bearer&expires_in=3600&state=STATE
 ```
 
 ### Examples of Negative Responses<a name="get-authorize-negative"></a>


### PR DESCRIPTION
Change `redirect_ur` typo to `redirect_uri`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
