### PR TITLE
Update token-endpoint.md

### DIFF
--- a/doc_source/token-endpoint.md
+++ b/doc_source/token-endpoint.md
@@ -201,4 +201,4 @@ Authorization code has been consumed already or does not exist\.
 Client is not allowed for code grant flow or for refreshing tokens\. 
 
 *unsupported\_grant\_type*  
-Returned if `grant_type` is anything other than `authorization_code` or `refresh_token`\. 
+Returned if `grant_type` is anything other than `authorization_code` or `refresh_token` or `client_credentials`\. 


### PR DESCRIPTION
Updated description of `unsupported_grant_type` error by including `client_credentials` grant type into the list of supported ones.

*Description of changes:*
Within the description of `unsupported_grant_type` there wasn't mentioned one of the supported grant types (`client_credentials` ) - added it to the description.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
