### PR TITLE
Triggers: Add python snippet for user pool lambda triggers

### DIFF
--- a/doc_source/user-pool-lambda-migrate-user.md
+++ b/doc_source/user-pool-lambda-migrate-user.md
@@ -147,3 +147,48 @@ exports.handler = (event, context, callback) => {
 ```
 
 ------
+#### [ Python ]
+
+```
+def lambda_handler(event, context, callback):
+
+    if event.triggerSource == "UserMigration_Authentication":
+
+        # authenticate the user with your existing user directory service
+        user = authenticateUser(event.userName, event.request.password)
+        if user:
+            event.response.userAttributes = {
+                "email": user.emailAddress,
+                "email_verified": "true"
+            }
+            event.response.finalUserStatus = "CONFIRMED"
+            event.response.messageAction = "SUPPRESS"
+            context.succeed(event)
+        
+        else:
+            # Return error to Amazon Cognito
+            callback("Bad password");
+
+    elif event.triggerSource == "UserMigration_ForgotPassword":
+
+        # Lookup the user in your existing user directory service
+        user = lookupUser(event.userName)
+        if user:
+            event.response.userAttributes = {
+                "email": user.emailAddress,
+                # required to enable password-reset code to be sent to user
+                "email_verified": "true"  
+            }
+            event.response.messageAction = "SUPPRESS"
+            context.succeed(event)
+        
+        else:
+            # Return error to Amazon Cognito
+            callback("Bad password")
+
+    else:
+        # Return error to Amazon Cognito
+        callback("Bad triggerSource " + event.triggerSource)
+```
+
+------


### PR DESCRIPTION
*Issue #39*

*Description of changes:*
Adding python code snippets alongside existing Node.js snippets in User pool lambda triggers. The following documentations are affected:

- [ ] Post Confirmation 
- [ ] Auth Challenge
- [ ] Custom email sender
- [ ] Custom message
- [ ] Custom SMS sender
- [ ] Pre-token Generation
- [ ] Verify Auth Challenge
- [x] Migrate User

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
