### PR TITLE
Fix IAM policy condition for SES authorization

### DIFF
--- a/doc_source/cognito-user-pool-settings-ses-authorization-to-send-email.md
+++ b/doc_source/cognito-user-pool-settings-ses-authorization-to-send-email.md
@@ -30,10 +30,10 @@ In this example, the "Sid" value is an arbitrary string that uniquely identifies
             "Resource": "<your SES identity ARN>",
             "Condition": {
                 "StringEquals": {
-                    "AWS:SourceAccount": "<your account number>"
+                    "aws:SourceAccount": "<your account number>"
                 },
                 "ArnLike": {
-                    "AWS:SourceArn": "<your identity pool ARN>"
+                    "aws:SourceArn": "<your identity pool ARN>"
                 }
             }
         }


### PR DESCRIPTION
Current example gives the error:
`InvalidPolicy: Unknown or unapplicable condition field 'AWS:SourceAccount'.`
