### PR TITLE
Fix commas in JWT header example

### DIFF
--- a/doc_source/amazon-cognito-user-pools-using-the-id-token.md
+++ b/doc_source/amazon-cognito-user-pools-using-the-id-token.md
@@ -12,8 +12,8 @@ The header contains two pieces of information: the key ID \(`kid`\), and the alg
 
 ```
 {
-"kid" : "1234example="
-"alg" : "RS256",
+"kid" : "1234example=",
+"alg" : "RS256"
 }
 ```
 


### PR DESCRIPTION
This small PR fixes the commas in the example header of a JWT.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
